### PR TITLE
Changed Provider to use form_params instead of deprecated body

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -1,6 +1,7 @@
 <?php
 namespace SocialiteProviders\Reddit;
 
+use GuzzleHttp\ClientInterface;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
 use Laravel\Socialite\Two\User;
@@ -61,10 +62,12 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => ['Accept' => 'application/json'],
             'auth' => [$this->clientId, $this->clientSecret],
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         return $this->parseAccessToken($response->getBody());

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -64,7 +64,7 @@ class Provider extends AbstractProvider implements ProviderInterface
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => ['Accept' => 'application/json'],
             'auth' => [$this->clientId, $this->clientSecret],
-            'body' => $this->getTokenFields($code),
+            'form_params' => $this->getTokenFields($code),
         ]);
 
         return $this->parseAccessToken($response->getBody());


### PR DESCRIPTION
The usage of body in the request options array has been deprecated in favor of "form_params" or "multipart".

Example error in laravel 5.1

```
InvalidArgumentException in Client.php line 380:
Passing in the "body" request option as an array to send a POST request has been deprecated. Please use the "form_params" request option to send a application/x-www-form-urlencoded request, or a the "multipart" request option to send a multipart/form-data request.
in Client.php line 380
at Client->invalidBody() in Client.php line 118
at Client->requestAsync('post', 'https://ssl.reddit.com/api/v1/access_token', array('headers' => array('Accept' => 'application/json'), 'auth' => array('id', 'secret'), 'body' => array('grant_type' => 'authorization_code', 'code' => 'code', 'redirect_uri' => 'http://localhost:5555/login'), 'synchronous' => true)) in Client.php line 130
at Client->request('post', 'https://ssl.reddit.com/api/v1/access_token', array('headers' => array('Accept' => 'application/json'), 'auth' => array('id', 'secret'), 'body' => array('grant_type' => 'authorization_code', 'code' => 'code', 'redirect_uri' => 'http://localhost:5555/login'))) in Client.php line 88
at Client->__call('post', array('https://ssl.reddit.com/api/v1/access_token', array('headers' => array('Accept' => 'application/json'), 'auth' => array('id', 'secret'), 'body' => array('grant_type' => 'authorization_code', 'code' => 'code', 'redirect_uri' => 'http://localhost:5555/login')))) in Provider.php line 68
at Client->post('https://ssl.reddit.com/api/v1/access_token', array('headers' => array('Accept' => 'application/json'), 'auth' => array('id', 'secret'), 'body' => array('grant_type' => 'authorization_code', 'code' => 'code', 'redirect_uri' => 'http://localhost:5555/login'))) in Provider.php line 68
at Provider->getAccessToken('code') in AbstractProvider.php line 180
```
