### PR TITLE
Compability issues fixed

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -66,7 +66,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getAccessToken($code)
+    public function getAccessTokenResponse($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => [

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider implements ProviderInterface
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->credentialsResponseBody;
     }
 
     /**


### PR DESCRIPTION
Fixed compability issues with version 2.0.17 of Socialite.

Changes:
- Method getAccessToken() renamed to getAccessTokenResponse()
- The return is not parsed within the function anymore, since it'll be parsed later on.
